### PR TITLE
fix for issue #73

### DIFF
--- a/.github/workflows/pythontesting.yml
+++ b/.github/workflows/pythontesting.yml
@@ -14,7 +14,14 @@ on:
 # This job installs dependencies, build the book, and pushes it to `gh-pages`
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    name: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+
     steps:
     - uses: actions/checkout@v2
     - uses: goanpeca/setup-miniconda@v1

--- a/R/py_int/covid_run.R
+++ b/R/py_int/covid_run.R
@@ -43,7 +43,7 @@ run_status <- function(pop,
   print(paste("R timestep:", timestep))
   
   if(timestep==1) {
-    tmp.dir <<- paste(getwd(),"/output/",Sys.time(),sep="")
+    tmp.dir <<- paste0(getwd(), "/output/", gsub(" ","-",Sys.time()))
     if(!dir.exists(tmp.dir)){
       dir.create(tmp.dir, recursive = TRUE)
     }

--- a/R/py_int/covid_run.R
+++ b/R/py_int/covid_run.R
@@ -43,7 +43,9 @@ run_status <- function(pop,
   print(paste("R timestep:", timestep))
   
   if(timestep==1) {
-    tmp.dir <<- paste0(getwd(), "/output/", gsub(" ","-",Sys.time()))
+    # windows does not allow colons in folder names so substitute sys.time() to hyphen
+    tmp.dir <<- paste0(getwd(), "/output/", gsub(":","-", gsub(" ","-",Sys.time())))
+
     if(!dir.exists(tmp.dir)){
       dir.create(tmp.dir, recursive = TRUE)
     }

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - pytest=5.4.1
   - matplotlib=3.1.3
   - swifter=0.304
-  - rpy2=3.3.2
+  - rpy2=2.9.4
   - tzlocal
   - r-mixdist
   - r-tidyr=1.1.0


### PR DESCRIPTION
changes include:
- added OS matrix to github actions for test runners on Windows, macOS and Ubuntu
- reverting rpy2 to 2.9.4 to fix OSError

notes:
- tests still fail on windows on test_random now issue #75