### PR TITLE
split functions

### DIFF
--- a/R/py_int/covid_run.R
+++ b/R/py_int/covid_run.R
@@ -1,29 +1,30 @@
-# list.of.packages <- c("rampuaR")
-# new.packages <- list.of.packages[!(list.of.packages %in% installed.packages()[,"Package"])]
 
-# if(length(new.packages)) devtools::install_github("Urban-Analytics/rampuaR", dependencies = F)
+load_rpackages <- function() {
+  list.of.packages <- c("rampuaR")
+  new.packages <- list.of.packages[!(list.of.packages %in% installed.packages()[,"Package"])]
 
-# library(rvcheck)
-# 
-# rampr_version <- check_github("Urban-Analytics/rampuaR")
-# if(!rampr_version$up_to_date) devtools::install_github("Urban-Analytics/rampuaR", dependencies = F)
+  if(length(new.packages)) devtools::install_github("Urban-Analytics/rampuaR", dependencies = F)
 
+  library(rvcheck)
 
-devtools::install_github("Urban-Analytics/rampuaR", dependencies = F)
+  rampr_version <- check_github("Urban-Analytics/rampuaR")
+  if(!rampr_version$up_to_date) devtools::install_github("Urban-Analytics/rampuaR", dependencies = F)
 
-library(tidyr)
-library(readr)
-library(mixdist)
-library(dplyr)
-library(rampuaR)
+  #devtools::install_github("Urban-Analytics/rampuaR", dependencies = F)
 
+  library(tidyr)
+  library(readr)
+  library(mixdist)
+  library(dplyr)
+  library(rampuaR)
+}
 
-data(gam_cases)
-data(msoas)
-
-w <- NULL
-model_cases <- NULL
-
+load_init_data <- function() {
+  data(gam_cases)
+  data(msoas)
+  w <- NULL
+  model_cases <- NULL
+}
 
 run_status <- function(pop,
                        timestep = 1,
@@ -57,7 +58,7 @@ run_status <- function(pop,
     }
   }
 
-if(output_switch){write.csv(pop, paste0( tmp.dir,"/daily_", timestep, ".csv"))}
+  if(output_switch){write.csv(pop, paste0( tmp.dir,"/daily_", timestep, ".csv"))}
 
   df_cr_in <-create_input(micro_sim_pop  = pop,
                           vars = c("area",   # must match columns in the population data.frame
@@ -124,7 +125,6 @@ if(output_switch){write.csv(pop, paste0( tmp.dir,"/daily_", timestep, ".csv"))}
     }
   }
 
-
   df_inf <- infection_length(df = df_ass,
                              exposed_dist = exposed_dist,
                              exposed_mean = exposed_mean,
@@ -159,7 +159,3 @@ if(output_switch){write.csv(pop, paste0( tmp.dir,"/daily_", timestep, ".csv"))}
 
   return(df_out)
 }
-
-
-
-

--- a/microsim/r_interface.py
+++ b/microsim/r_interface.py
@@ -56,6 +56,8 @@ class RInterface():
         del individuals_reduced["House_ID"]
 
         # Call the R function. The returned object will be converted to a pandas dataframe implicitly
+        self.R.load_rpackages()
+        self.R.load_init_data()
         r_df = self.R.run_status(individuals_reduced, iteration, **disease_params)
 
         assert len(r_df) == len(individuals)


### PR DESCRIPTION
I split the functions in covid_run up. we now have the pipeline function, but i put the package installation and loading and the data loading into functions. This way we can just call them once each time the microsim model is run and not each time the r code is run. i added the calls to the functions in the r_interface script, but i think they are in the wrong place. they will be called every timestep as is but i want them to be called once only