### PR TITLE
final fix #75

### DIFF
--- a/microsim/microsim_model.py
+++ b/microsim/microsim_model.py
@@ -101,7 +101,7 @@ class Microsim:
         self.hazard_multiplier_symptomatic = hazard_multiplier_symptomatic
         self.risk_multiplier = risk_multiplier
         self.lockdown_from_file = lockdown_from_file
-        self.random = random.Random(time.time() if random_seed is None else random_seed)
+        self.random = random.Random(None if random_seed is None else random_seed)
         self.output = output
         self.r_script_dir = r_script_dir
         Microsim.debug = debug

--- a/tests/test_microsim_model.py
+++ b/tests/test_microsim_model.py
@@ -427,8 +427,6 @@ def test_random():
     # Create a large number of microsims and check that all random numbers are unique
     pool = multiprocessing.Pool()
     num_reps = 250
-    # Note: Windows seems to only be able to generate 278 random numbers, so num_reps should be lower
-    # than that otherwise the windows tests fail
     m = [Microsim(**microsim_args, read_data=False) for _ in range(num_reps)]
     r = pool.map(_get_rand, m)
     assert len(r) == len(set(r))


### PR DESCRIPTION
remove time.time() random seed setting if random seed is none and allow to default to os randomness sources