### PR TITLE
this line will install opencl model pip requirements

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -36,5 +36,7 @@ dependencies:
   - r-rvcheck
   - r-stringdist
   - git-lfs
+  - pip=20
   - pip:
      - convertbng==0.6.25
+     - -r file:microsim/opencl/requirements.txt


### PR DESCRIPTION
I noticed you have a requirements.txt file in the opencl directory, we can have conda automatically install from this file by include this line in the environment.yml.

I've also specified a pip version in the conda installs to remove that warning message Nick identified.