### PR TITLE
bump version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="RAMP-UA",
-    version="0.3.0dev",
+    version="0.4.0dev",
     author="RAMP UA Team",
     author_email="N.S.Malleson@leeds.ac.uk",
     description="The RAMP Urban Analytics package",


### PR DESCRIPTION
this commit bumps the version number for release v0.4.0 and aligns history on master before openCL model merge