### PR TITLE
Lognormal distribution in OpenCL code

### DIFF
--- a/microsim/opencl/doc/model_design.md
+++ b/microsim/opencl/doc/model_design.md
@@ -92,8 +92,8 @@ typedef struct Params {
   float exposed_shape; // The shape of the distribution of exposed durations
   float presymp_scale; // The scale of the distribution of presymptomatic durations
   float presymp_shape; // The shape of the distribution of presymptomatic durations
-  float infection_scale; // The scale of the distribution of infected durations
-  float infection_loc; // The location of the distribution of infected durations
+  float infection_log_scale; // The std dev of the underlying normal distribution of the lognormal infected duration distribution
+  float infection_mode; // The mode of the lognormal distribution of infected durations
   float lockdown_multiplier; // Increase in time at home due to lockdown
   float place_hazard_multipliers[5]; // Hazard multipliers by activity
   float recovery_probs[9]; // Recovery probabilities by age group

--- a/microsim/opencl/ramp/inspector.py
+++ b/microsim/opencl/ramp/inspector.py
@@ -434,10 +434,10 @@ class Inspector:
             "Presymptomatic Weibull Scale", self.params.presymptomatic_scale, 0.0, 10.0)
         _, self.params.presymptomatic_shape = imgui.slider_float(
             "Presymptomatic Weibull Shape", self.params.presymptomatic_shape, 0.0, 10.0)
-        _, self.params.infection_scale = imgui.slider_float(
-            "Infection Normal Std Dev", self.params.infection_scale, 0.0, 10.0)
-        _, self.params.infection_location = imgui.slider_float(
-            "Infection Normal Mean", self.params.infection_location, 0.0, 20.0)
+        _, self.params.infection_sd_log = imgui.slider_float(
+            "Infection Normal Std Dev", self.params.infection_sd_log, 0.0, 10.0)
+        _, self.params.infection_mode = imgui.slider_float(
+            "Infection Normal Mean", self.params.infection_mode, 0.0, 20.0)
 
         imgui.text("Activity Hazard Multipliers")
 

--- a/microsim/opencl/ramp/kernels/prng.cl
+++ b/microsim/opencl/ramp/kernels/prng.cl
@@ -54,5 +54,5 @@ float rand_weibull(global uint4* rng, float scale, float shape) {
 }
 
 float lognormal(global uint4* rng, float meanlog, float sdlog){
-  return exp(meanlog + sdlog * rand(rng));
+  return exp(meanlog + sdlog * randn(rng));
 }

--- a/microsim/opencl/ramp/kernels/prng.cl
+++ b/microsim/opencl/ramp/kernels/prng.cl
@@ -52,3 +52,7 @@ float rand_exp(global uint4* rng) {
 float rand_weibull(global uint4* rng, float scale, float shape) {
   return scale * pow(rand_exp(rng), ((float)1.0 / shape));
 }
+
+float lognormal(global uint4* rng, float meanlog, float sdlog){
+  return exp(meanlog + sdlog * rand(rng));
+}

--- a/microsim/opencl/ramp/kernels/ramp_ua.cl
+++ b/microsim/opencl/ramp/kernels/ramp_ua.cl
@@ -58,8 +58,8 @@ typedef struct Params {
   float exposed_shape; // The shape of the distribution of exposed durations
   float presymp_scale; // The scale of the distribution of presymptomatic durations
   float presymp_shape; // The shape of the distribution of presymptomatic durations
-  float infection_scale; // The scale of the distribution of infected durations
-  float infection_loc; // The location of the distribution of infected durations
+  float infection_log_scale; // The std dev of the underlying normal distribution of the lognormal infected duration distribution
+  float infection_mode; // The mode of the lognormal distribution of infected durations
   float lockdown_multiplier; // Increase in time at home due to lockdown
   float place_hazard_multipliers[5]; // Hazard multipliers by activity
   float individual_hazard_multipliers[3]; // Hazard multipliers by activity
@@ -92,9 +92,10 @@ uint sample_presymptomatic_duration(global uint4* rng, global const Params* para
 }
 
 uint sample_infection_duration(global uint4* rng, global const Params* params){
-  // FIXME: This is lognormal now
-  float sample = randn(rng) * params->infection_scale + params->infection_loc;
-  return sample * sign(sample); // Folded normal
+  float mode = params->infection_mode;
+  float sdlog = params->infection_log_scale;
+  float meanlog = pow(sdlog, 2) + log(mode);
+  return (uint)lognormal(rng, meanlog, sdlog);
 }
 
 float get_recovery_prob_for_age(ushort age, global const Params* params){

--- a/microsim/opencl/ramp/params.py
+++ b/microsim/opencl/ramp/params.py
@@ -47,8 +47,8 @@ class Params:
         self.exposed_shape = 3.93
         self.presymptomatic_scale = 2.45
         self.presymptomatic_shape = 7.12
-        self.infection_log_scale = 3.0
-        self.infection_mode = 10.0
+        self.infection_log_scale = 0.75
+        self.infection_mode = 7.0
         self.lockdown_multiplier = 1.0
         self.place_hazard_multipliers = np.array([location_hazard_multipliers.retail,
                                                   location_hazard_multipliers.primary_school,

--- a/microsim/opencl/ramp/params.py
+++ b/microsim/opencl/ramp/params.py
@@ -47,8 +47,8 @@ class Params:
         self.exposed_shape = 3.93
         self.presymptomatic_scale = 2.45
         self.presymptomatic_shape = 7.12
-        self.infection_scale = 3.0
-        self.infection_location = 16.0
+        self.infection_log_scale = 3.0
+        self.infection_mode = 10.0
         self.lockdown_multiplier = 1.0
         self.place_hazard_multipliers = np.array([location_hazard_multipliers.retail,
                                                   location_hazard_multipliers.primary_school,
@@ -75,8 +75,8 @@ class Params:
                     self.exposed_shape,
                     self.presymptomatic_scale,
                     self.presymptomatic_shape,
-                    self.infection_scale,
-                    self.infection_location,
+                    self.infection_log_scale,
+                    self.infection_mode,
                     self.lockdown_multiplier,
                 ],
                 dtype=np.float32,
@@ -107,8 +107,8 @@ class Params:
         p.exposed_shape = params_array[3]
         p.presymptomatic_scale = params_array[4]
         p.presymptomatic_shape = params_array[5]
-        p.infection_scale = params_array[6]
-        p.infection_location = params_array[7]
+        p.infection_log_scale = params_array[6]
+        p.infection_mode = params_array[7]
         p.lockdown_multiplier = params_array[8]
         p.recovery_probs = params_array[17:26]
         return p

--- a/tests/opencl/test_update_statuses_kernel.py
+++ b/tests/opencl/test_update_statuses_kernel.py
@@ -1,5 +1,7 @@
 import numpy as np
 from matplotlib import pyplot as plt
+import scipy.stats
+from microsim.opencl.ramp.params import Params
 from microsim.opencl.ramp.simulator import Simulator
 from microsim.opencl.ramp.snapshot import Snapshot
 from microsim.opencl.ramp.disease_statuses import DiseaseStatus
@@ -8,7 +10,7 @@ nplaces = 8
 npeople = 50000
 nslots = 8
 
-visualize = False
+visualize = True
 
 
 def test_susceptible_become_infected():
@@ -286,7 +288,7 @@ def test_all_asymptomatic_become_recovered():
     assert np.all(people_statuses_after_two_steps == DiseaseStatus.Recovered.value)
 
 
-def test_transition_times_distribution():
+def test_infection_transition_times_distribution():
     npeople = 50000
     snapshot = Snapshot.random(nplaces, npeople, nslots)
 
@@ -300,6 +302,13 @@ def test_transition_times_distribution():
     snapshot.buffers.people_statuses[:] = people_statuses_test_data
     snapshot.buffers.people_transition_times[:] = people_transition_times_test_data
 
+    params = Params()
+    infection_log_scale = 0.75
+    infection_mode = 7.0
+    params.infection_log_scale = infection_log_scale
+    params.infection_mode = infection_mode
+    snapshot.update_params(params)
+
     simulator = Simulator(snapshot, gpu=False)
     simulator.upload_all(snapshot.buffers)
 
@@ -311,20 +320,33 @@ def test_transition_times_distribution():
     people_transition_times_after = np.zeros(npeople, dtype=np.uint32)
     simulator.download("people_transition_times", people_transition_times_after)
 
-    # Check that transition times are normally distributed with mean 14 and standard dev 2
-    # NB: We increment times by 1 since 1 day will already have been subtracted
-    expected_mean = 16.0
-    expected_std_dev = 3.0
+    # Check that transition times are distributed with a log-normal distribution
+    adjusted_transition_times = people_transition_times_after+1
+    mean = adjusted_transition_times.mean()
+    std_dev = adjusted_transition_times.std()
+    mode = scipy.stats.mode(adjusted_transition_times)
+    kurtosis = scipy.stats.kurtosis(adjusted_transition_times)
 
-    mean = (people_transition_times_after+1).mean()
-    std_dev = (people_transition_times_after+1).std()
+    meanlog = infection_log_scale**2 + np.log(infection_mode)
+    expected_samples = np.random.lognormal(mean=meanlog, sigma=infection_log_scale, size=npeople)
+    expected_mean = expected_samples.mean()
+    expected_std_dev = expected_samples.std()
+    expected_mode = scipy.stats.mode(expected_samples)
+    expected_kurtosis = scipy.stats.kurtosis(expected_samples)
 
     # Float to integer rounding and clamping at zero makes the original random numbers hard
     # to recover so we have slightly larger tolerances here to avoid false negatives.
-    assert np.isclose(expected_mean, mean, atol=0.7)
-    assert np.isclose(expected_std_dev, std_dev, atol=0.2)
+    # assert np.isclose(expected_mean, mean, atol=0.7)
+    # assert np.isclose(expected_std_dev, std_dev, atol=0.2)
+    # assert np.isclose(expected_mode, mode, atol=0.2)
+    # assert np.isclose(expected_kurtosis, kurtosis, atol=0.2)
 
     if visualize:  # show histogram of distribution
         fig, ax = plt.subplots(1, 1)
-        ax.hist(people_transition_times_after)
+        ax.hist(adjusted_transition_times, bins=100)
+        plt.title("Result Samples")
+        plt.show()
+        fig, ax = plt.subplots(1, 1)
+        ax.hist(expected_samples, bins=50)
+        plt.title("Expected Samples")
         plt.show()

--- a/tests/opencl/test_update_statuses_kernel.py
+++ b/tests/opencl/test_update_statuses_kernel.py
@@ -287,7 +287,7 @@ def test_all_asymptomatic_become_recovered():
 
 
 def test_infection_transition_times_distribution(visualize=False):
-    npeople = 500000
+    npeople = 1000000
     snapshot = Snapshot.random(nplaces, npeople, nslots)
 
     test_hazard = 0.9
@@ -323,7 +323,6 @@ def test_infection_transition_times_distribution(visualize=False):
     mean = adjusted_transition_times.mean()
     std_dev = adjusted_transition_times.std()
     mode = scipy.stats.mode(adjusted_transition_times)[0][0]
-    kurtosis = scipy.stats.kurtosis(adjusted_transition_times)
 
     meanlog = infection_log_scale**2 + np.log(infection_mode)
     expected_samples = np.random.lognormal(mean=meanlog, sigma=infection_log_scale, size=npeople)
@@ -332,14 +331,15 @@ def test_infection_transition_times_distribution(visualize=False):
     expected_mean = expected_samples.mean()
     expected_std_dev = expected_samples.std()
     expected_mode = scipy.stats.mode(expected_samples)[0][0]
-    expected_kurtosis = scipy.stats.kurtosis(expected_samples)
 
     # Float to integer rounding and clamping at zero makes the original random numbers hard
     # to recover so we have slightly larger tolerances here to avoid false negatives.
     assert np.isclose(expected_mean, mean, atol=0.7)
-    assert np.isclose(expected_std_dev, std_dev, atol=0.2)
-    assert np.isclose(expected_mode, mode, atol=0.2)
-    assert np.isclose(expected_kurtosis, kurtosis, atol=0.2)
+    assert np.isclose(expected_std_dev, std_dev, atol=0.4)
+    assert np.isclose(expected_mode, mode, atol=0.7)
+
+    # check that mode is similar to original mode parameter
+    assert np.isclose(infection_mode, mode, atol=0.7)
 
     if visualize:  # show histogram of distribution
         fig, ax = plt.subplots(1, 1)


### PR DESCRIPTION
This PR adds a lognormal distribution for the infection duration in the OpenCL kernel code.

**NB** the input parameters for the lognormal distribution are handled slightly differently from the existing R implementation (or at least from my best understanding of the current R implementation, I may be mistaken!). I've described both implementations below to highlight the difference. This is not really a question of what is "correct", but more a question of how we want to specify the shape of the lognormal distribution in a meaningful and useful way. Perhaps if we have time we can discuss this at our meeting on handling disease probabilities tomorrow (Tuesday). 

### Current R implementation lognormal params
The current implementation has two parameters for the infection distribution called  `infection_mean` and `infection_sd`, which are currently set to **18.0** and **1.1** respectively. The log of both these values is then taken before being passed to the lognormal function, which can be seen in the [rampuaR repo here](https://github.com/Urban-Analytics/rampuaR/blob/5d803a670f9f059614daf3eb9a4d2e319e5cdaba/R/covid_status_functions.R#L329) 

From my understanding the input `mu` and `sigma` parameters of a lognormal distribution (including the R `rlnorm` function) represent the mean and standard deviation of the _log_ of the random variable, see [wikipedia](https://en.wikipedia.org/wiki/Log-normal_distribution#Generation_and_parameters).

What this means is that the current `infection_mean` and `infection_sd` do not have a meaningful interpretation, even though obviously they can be used to specify the shape of the resulting lognormal distribution.

### Proposed lognormal params implemented in this PR
However in the implementation in this PR I have specified two input parameters called `infection_log_scale` and `infection_mode`. The `infection_log_scale` represents the `sigma` input parameter to the lognormal distribution (so the standard dev of the log of the distribution). The `infection_mode` represents the mode of the resulting distribution, eg. the highest point on the pdf of the distribution. I figured that the mode is quite an intuitive way to specify the shape of the lognormal distribution.

From this mode and sigma value the `mu` input (eg. the mean of the log of the distribution) is easily computed by the following formula (see [wikipedia](https://en.wikipedia.org/wiki/Log-normal_distribution#Mode,_median,_quantiles)):
```
mu = log(mode) + sigma^2
```  

I've set the default values of these parameters as `infection_mode=7.0` and `infection_log_scale=0.75`. The OpenCL implementation with these values produces the distribution below. Obviously these values are easily changed, it may be nice to find some references for these values from the epidemiology literature. The random spikes along the distribution are an artifact of rounding the samples to integers.
![lognormal_samples](https://user-images.githubusercontent.com/33732077/95769411-be830600-0caf-11eb-9d00-03337c35b53b.png)

I've also written a test that compares properties of the resulting distribution to samples from the `numpy.random.lognormal` function.
