### PR TITLE
Obesity affects asympomatic rate AND fix problem with SEIR disease state progression

### DIFF
--- a/microsim/opencl/ramp/kernels/ramp_ua.cl
+++ b/microsim/opencl/ramp/kernels/ramp_ua.cl
@@ -64,7 +64,7 @@ typedef struct Params {
   float place_hazard_multipliers[5]; // Hazard multipliers by activity
   float individual_hazard_multipliers[3]; // Hazard multipliers by activity
   float mortality_probs[9]; // mortality probabilities by age group
-  float obesity_multipliers[3]; // mortality multipliers for obesity levels
+  float obesity_multipliers[4]; // mortality multipliers for obesity levels
   float cvd_multiplier; // mortality multipliers for cardiovascular disease
   float diabetes_multiplier; // mortality multipliers for diabetes
   float bloodpressure_multiplier; // mortality multipliers for high blood pressure

--- a/microsim/opencl/ramp/kernels/ramp_ua.cl
+++ b/microsim/opencl/ramp/kernels/ramp_ua.cl
@@ -68,6 +68,7 @@ typedef struct Params {
   float cvd_multiplier; // mortality multipliers for cardiovascular disease
   float diabetes_multiplier; // mortality multipliers for diabetes
   float bloodpressure_multiplier; // mortality multipliers for high blood pressure
+  float overweight_sympt_mplier; // multiplier for probability of overweight people to become symptomatic 
 } Params;
 
 
@@ -112,6 +113,10 @@ float get_obesity_multiplier(ushort obesity, global const Params* params){
     // obesity value of 0 corresponds to normal, so there is no multiplier for that
     int multiplier_idx = (int)obesity - 1;
     return params->obesity_multipliers[multiplier_idx];
+}
+
+bool is_overweight(ushort obesity){
+  return obesity > 0;
 }
 
 /*
@@ -301,14 +306,24 @@ kernel void people_update_statuses(uint npeople,
     switch(current_status) {
         case Exposed:
         {
-          next_status = Presymptomatic;
-          next_transition_time = sample_presymptomatic_duration(rng, params);
+          float symp_rate = 1 - params->proportion_asymptomatic;
+
+          // being overweight increases chances of being symptomatic
+          if (is_overweight(people_obesity[person_id])){
+            symp_rate *= params->overweight_sympt_mplier;
+          }
+
+          // randomly select whether to become asymptomatic or presymptomatic
+          next_status = rand(rng) < symp_rate ? Presymptomatic : Asymptomatic;
+          
+          //choose transition time based on presymptomatic or asymptomatic
+          next_transition_time = next_status == Presymptomatic ? sample_presymptomatic_duration(rng, params) : sample_infection_duration(rng, params);
+          
           break;
         }
         case Presymptomatic:
         {
-          // randomly select whether asymptomatic or not
-          next_status = rand(rng) < params->proportion_asymptomatic ? Asymptomatic : Symptomatic;
+          next_status = Symptomatic;
           next_transition_time = sample_infection_duration(rng, params);
           break;
         }

--- a/microsim/opencl/ramp/params.py
+++ b/microsim/opencl/ramp/params.py
@@ -43,6 +43,7 @@ class Params:
                  cvd_multiplier=1,
                  diabetes_multiplier=1,
                  bloodpressure_multiplier=1,
+                 overweight_sympt_mplier=1.46
                  ):
         """Create a simulator with the default parameters."""
         if obesity_multipliers is None:
@@ -74,6 +75,7 @@ class Params:
         self.cvd_multiplier = cvd_multiplier
         self.diabetes_multiplier = diabetes_multiplier
         self.bloodpressure_multiplier = bloodpressure_multiplier
+        self.overweight_sympt_mplier = overweight_sympt_mplier
 
     def asarray(self):
         """Pack the parameters into a flat array for uploading."""
@@ -100,7 +102,8 @@ class Params:
                 [
                     self.cvd_multiplier,
                     self.diabetes_multiplier,
-                    self.bloodpressure_multiplier
+                    self.bloodpressure_multiplier,
+                    self.overweight_sympt_mplier
                 ],
                 dtype=np.float32,
             )
@@ -135,6 +138,7 @@ class Params:
         p.cvd_multiplier = params_array[30]
         p.diabetes_multiplier = params_array[31]
         p.bloodpressure_multiplier = params_array[32]
+        p.overweight_sympt_mplier = params_array[33]
         return p
 
     def set_lockdown_multiplier(self, lockdown_multipliers, timestep):

--- a/tests/opencl/test_update_statuses_kernel.py
+++ b/tests/opencl/test_update_statuses_kernel.py
@@ -77,87 +77,6 @@ def test_transmission_times_decremented():
     assert np.array_equal(expected_people_transition_times, people_transmission_times_after)
 
 
-# def test_exposed_become_presymptomatic():
-#     snapshot = Snapshot.random(nplaces, npeople, nslots)
-#
-#     people_statuses_test_data = np.full(npeople, DiseaseStatus.Exposed.value, dtype=np.uint32)
-#
-#     people_transition_times_test_data = np.full(npeople, 1, dtype=np.uint32)
-#
-#     snapshot.buffers.people_statuses[:] = people_statuses_test_data
-#     snapshot.buffers.people_transition_times[:] = people_transition_times_test_data
-#
-#     simulator = Simulator(snapshot, gpu=False)
-#     simulator.upload_all(snapshot.buffers)
-#
-#     people_statuses_before = np.zeros(npeople, dtype=np.uint32)
-#     simulator.download("people_statuses", people_statuses_before)
-#
-#     assert np.array_equal(people_statuses_before, people_statuses_test_data)
-#
-#     simulator.step_kernel("people_update_statuses")
-#
-#     # check that statuses don't change after one step
-#     people_statuses_after_one_step = np.zeros(npeople, dtype=np.uint32)
-#     simulator.download("people_statuses", people_statuses_after_one_step)
-#
-#     assert np.array_equal(people_statuses_after_one_step, people_statuses_test_data)
-#
-#     # run another timestep, this time statuses should change
-#     simulator.step_kernel("people_update_statuses")
-#
-#     # assert that all statuses change to presymptomatic after two timesteps
-#     people_statuses_after_two_steps = np.zeros(npeople, dtype=np.uint32)
-#     simulator.download("people_statuses", people_statuses_after_two_steps)
-#
-#     assert np.all(people_statuses_after_two_steps == DiseaseStatus.Presymptomatic.value)
-
-
-# def test_presymptomatic_update_status():
-#     snapshot = Snapshot.random(nplaces, npeople, nslots)
-#
-#     people_statuses_test_data = np.full(npeople, DiseaseStatus.Presymptomatic.value, dtype=np.uint32)
-#
-#     people_transition_times_test_data = np.full(npeople, 1, dtype=np.uint32)
-#
-#     snapshot.buffers.people_statuses[:] = people_statuses_test_data
-#     snapshot.buffers.people_transition_times[:] = people_transition_times_test_data
-#
-#     simulator = Simulator(snapshot, gpu=False)
-#     simulator.upload_all(snapshot.buffers)
-#
-#     people_statuses_before = np.zeros(npeople, dtype=np.uint32)
-#     simulator.download("people_statuses", people_statuses_before)
-#
-#     assert np.array_equal(people_statuses_before, people_statuses_test_data)
-#
-#     simulator.step_kernel("people_update_statuses")
-#
-#     # check that statuses don't change after one step
-#     people_statuses_after_one_step = np.zeros(npeople, dtype=np.uint32)
-#     simulator.download("people_statuses", people_statuses_after_one_step)
-#
-#     assert np.array_equal(people_statuses_after_one_step, people_statuses_test_data)
-#
-#     # run another timestep, this time statuses should change
-#     simulator.step_kernel("people_update_statuses")
-#
-#     # assert that statuses change to either symptomatic or asymptomatic in the correct proportion
-#     people_statuses_after_two_steps = np.zeros(npeople, dtype=np.uint32)
-#     simulator.download("people_statuses", people_statuses_after_two_steps)
-#
-#     num_asymptomatic = np.count_nonzero(people_statuses_after_two_steps == DiseaseStatus.Asymptomatic.value)
-#     proportion_asymptomatic = num_asymptomatic / npeople
-#
-#     num_symptomatic = np.count_nonzero(people_statuses_after_two_steps == DiseaseStatus.Symptomatic.value)
-#     proportion_symptomatic = num_symptomatic / npeople
-#
-#     expected_proportion_asymptomatic = 0.4
-#     expected_proportion_symptomatic = 1 - expected_proportion_asymptomatic
-#
-#     assert np.isclose(expected_proportion_asymptomatic, proportion_asymptomatic, atol=0.01)
-#     assert np.isclose(expected_proportion_symptomatic, proportion_symptomatic, atol=0.01)
-
 def test_exposed_become_asymptomatic_or_presymptomatic():
     snapshot = Snapshot.random(nplaces, npeople, nslots)
 
@@ -172,7 +91,7 @@ def test_exposed_become_asymptomatic_or_presymptomatic():
     snapshot.buffers.people_transition_times[:] = people_transition_times_test_data
 
     params = Params()
-    expected_proportion_asymptomatic = 0.5
+    expected_proportion_asymptomatic = 0.45
     params.proportion_asymptomatic = expected_proportion_asymptomatic
     snapshot.update_params(params)
 
@@ -225,7 +144,7 @@ def test_more_overweight_become_symptomatic():
     snapshot.buffers.people_transition_times[:] = people_transition_times_test_data
 
     params = Params()
-    base_proportion_asymptomatic = 0.5
+    base_proportion_asymptomatic = 0.45
     params.proportion_asymptomatic = base_proportion_asymptomatic
     overweight_sympt_mplier = 1.2
     params.overweight_sympt_mplier = overweight_sympt_mplier


### PR DESCRIPTION
Overweight and obese people are now more likely to become symptomatic, in accordance with the logic in the R implementation [here](https://github.com/Urban-Analytics/rampuaR/blob/bf32495ad59595c342a563d3050a62eff69fcd03/R/covid_status_functions.R#L329). This adds the `overweight_sympt_mplier` to the parameters, which multiplies the symptomatic rate.

**Additionally** I fixed a fairly major bug in the OpenCL logic which progresses through disease states in the `people_update_statuses` kernel. This was because when I originally wrote this I misunderstood the disease progression, I thought everyone went from exposed to presymptomatic, then from presymptomatic either went to asymptomatic or symptomatic. Whereas the correct logic is that people go from exposed to either asymptomatic or presympomatic, then presymptomatic people transition to symptomatic.

This is perhaps most easily explained by the following diagram, showing the disease state progression before and after:

![SEIR_logic](https://user-images.githubusercontent.com/33732077/95967309-031fb600-0e04-11eb-8a97-16fbdb881992.png)

It would be useful if @spoonerf and @jabrams23 can confirm that this is indeed correct, and that I haven't misinterpreted the R code yet again! 
