### PR TITLE
Fix UI rollback bug

### DIFF
--- a/microsim/opencl/ramp/inspector.py
+++ b/microsim/opencl/ramp/inspector.py
@@ -325,7 +325,7 @@ class Inspector:
         glUniform2fv(glGetUniformLocation(self.places_program, "position"), 1, position)
         glUniform1fv(glGetUniformLocation(self.places_program, "scale"), 1, scale)
         glUniform1fv(glGetUniformLocation(self.places_program, "alpha"), 1, 0.01)
-        glDrawElements(GL_LINES, 2 * self.npeople * self.nlines, GL_UNSIGNED_INT, None);
+        glDrawElements(GL_LINES, 2 * self.npeople * self.nlines, GL_UNSIGNED_INT, None)
 
     def draw_platform_window(self, width, height):
         imgui.set_next_window_size(width / 6, height / 4)

--- a/microsim/opencl/ramp/inspector.py
+++ b/microsim/opencl/ramp/inspector.py
@@ -2,6 +2,7 @@ import glfw
 import imgui
 import numpy as np
 import os
+import copy
 
 from imgui.integrations.glfw import GlfwRenderer
 from OpenGL.GL import *
@@ -138,6 +139,7 @@ class Inspector:
 
         self.simulator = simulator
         self.snapshot = snapshot
+        self.initial_state_snapshot = copy.deepcopy(snapshot)
         self.params = Params.fromarray(snapshot.buffers.params)
         self.nplaces = nplaces
         self.npeople = npeople
@@ -349,7 +351,8 @@ class Inspector:
         if imgui.button("Step"):
             self.update_sim()
         if imgui.button("Rollback"):
-            self.snapshot = Snapshot.load_full_snapshot(f"{self.snapshot_dir}/{self.snapshots[self.current_snapshot]}")
+            # reset snapshot to the initial state when the inspector was created
+            self.snapshot = copy.deepcopy(self.initial_state_snapshot)
             self.simulator.upload_all(self.snapshot.buffers)
             self.simulator.time = self.snapshot.time
         _, self.do_lockdown = imgui.checkbox("Lockdown", self.do_lockdown)
@@ -434,10 +437,10 @@ class Inspector:
             "Presymptomatic Weibull Scale", self.params.presymptomatic_scale, 0.0, 10.0)
         _, self.params.presymptomatic_shape = imgui.slider_float(
             "Presymptomatic Weibull Shape", self.params.presymptomatic_shape, 0.0, 10.0)
-        _, self.params.infection_sd_log = imgui.slider_float(
-            "Infection Normal Std Dev", self.params.infection_sd_log, 0.0, 10.0)
+        _, self.params.infection_log_scale = imgui.slider_float(
+            "Infection Log-normal Scale", self.params.infection_log_scale, 0.0, 5.0)
         _, self.params.infection_mode = imgui.slider_float(
-            "Infection Normal Mean", self.params.infection_mode, 0.0, 20.0)
+            "Infection Log-normal Mode", self.params.infection_mode, 0.0, 20.0)
 
         imgui.text("Activity Hazard Multipliers")
 

--- a/microsim/opencl/ramp/snapshot.py
+++ b/microsim/opencl/ramp/snapshot.py
@@ -183,6 +183,8 @@ class Snapshot:
         # Set initial transition times to 1
         self.buffers.people_transition_times[initial_case_ids] = 1
 
+        self.time = num_seed_days
+
     def update_params(self, new_params):
         try:
             self.buffers.params[:] = new_params.asarray()

--- a/microsim/opencl/ramp/summary.py
+++ b/microsim/opencl/ramp/summary.py
@@ -71,6 +71,10 @@ class Summary:
                 DiseaseStatus.Dead.name.lower(): np.zeros((len(self.unique_area_codes), max_time)),
             }
 
+        # fill arrays up to current time with constant values
+        for i in range(snapshot.time):
+            self.update(i, snapshot.buffers.people_statuses)
+
     def get_df_columns(self):
         return [f"Day{i}" for i in range(self.max_time)]
 

--- a/tests/opencl/test_snapshots.py
+++ b/tests/opencl/test_snapshots.py
@@ -1,6 +1,7 @@
 from microsim.opencl.ramp.snapshot import Snapshot
 import numpy as np
 import os
+import copy
 
 sentinel_value = (1 << 31) - 1
 
@@ -116,3 +117,15 @@ def test_switch_to_healthier_population():
     expected_obesity = np.array([0, 0, 0, 0, 1, 1, 3, 3])
 
     assert np.array_equal(result_obesity, expected_obesity)
+
+
+def test_copy_snapshot():
+    snapshot = Snapshot.random(nplaces=50, npeople=8, nslots=5)
+    snapshot_copy = copy.deepcopy(snapshot)
+
+    # check buffer contents equal after copy
+    assert np.array_equal(snapshot.buffers.people_baseline_flows, snapshot_copy.buffers.people_baseline_flows)
+
+    # mutate original snapshot and check that the copy is no longer equal
+    snapshot.buffers.people_baseline_flows[:] = snapshot.buffers.people_baseline_flows * 2.5
+    assert not np.array_equal(snapshot.buffers.people_baseline_flows, snapshot_copy.buffers.people_baseline_flows)


### PR DESCRIPTION
This fixes a bug where pressing the "rollback" button in the UI wasn't working proprerly. This is because it was reloading the snapshot from the `cache.npz` file, however this didn't incorporate any changes to the snapshot which happened after the snapshot was loaded, eg. setting parameters read from the file. This mean it would only ever be using the default parameters in the Params class, which may be misleading.

Now this stores the initial state of the snapshot when the inspector runs by deep copying the snapshot object, then we can reload directly from that without reading the snapshot file from disk. The downside of this approach is that it uses extra memory, so we may have to reconsider this approach if the snapshots get really large. 

### Additionally
The summary data now records the timesteps corresponding to the initial seeding phase.