### PR TITLE
Updated hazard kernel function

### DIFF
--- a/microsim/opencl/ramp/kernels/ramp_ua.cl
+++ b/microsim/opencl/ramp/kernels/ramp_ua.cl
@@ -291,8 +291,8 @@ kernel void people_update_statuses(uint npeople,
   // assign new infections to susceptible people 
   if (current_status == Susceptible){
     float hazard = people_hazards[person_id];
-    // map hazard to probability between 0 and 1
-    float infection_prob = hazard / (hazard + exp(-hazard));
+    // Integrate hazard into probability
+    float infection_prob = 1.0 - exp(-hazard);
 
     // randomly sample if they should be infected or not based on infection probability
     if (rand(rng) < infection_prob) {

--- a/tests/opencl/test_update_statuses_kernel.py
+++ b/tests/opencl/test_update_statuses_kernel.py
@@ -42,7 +42,7 @@ def test_susceptible_become_infected():
     num_exposed = np.count_nonzero(people_statuses_after == DiseaseStatus.Exposed.value)
     proportion_exposed = num_exposed / npeople
 
-    expected_proportion_infected = test_hazard / (test_hazard + np.exp(-test_hazard))
+    expected_proportion_infected = 1.0 - np.exp(-test_hazard)
 
     assert np.isclose(expected_proportion_infected, proportion_exposed, atol=0.01)
 


### PR DESCRIPTION
- Updated the hazard function in the opencl code to be `1.0-exp(-hazard*dt)` where the `dt` is implicitly `1.0`.
- Updated the corresponding test
