### PR TITLE
Adjust healthier switch

### DIFF
--- a/microsim/opencl/ramp/snapshot.py
+++ b/microsim/opencl/ramp/snapshot.py
@@ -210,7 +210,8 @@ class Snapshot:
         to the level of obesity below their current one, by subtracting 1.
         """
         people_obesity = self.buffers.people_obesity
-        people_obesity[people_obesity > 0] -= 1
+        # only change people with obesity 2 and above, 2 corresponds to "Obese I"
+        people_obesity[people_obesity >= 2] -= 1
         self.buffers.people_obesity[:] = people_obesity
 
     @classmethod

--- a/tests/opencl/test_snapshots.py
+++ b/tests/opencl/test_snapshots.py
@@ -114,7 +114,7 @@ def test_switch_to_healthier_population():
     snapshot.switch_to_healthier_population()
 
     result_obesity = snapshot.buffers.people_obesity
-    expected_obesity = np.array([0, 0, 0, 0, 1, 1, 3, 3])
+    expected_obesity = np.array([0, 0, 1, 1, 1, 1, 3, 3])
 
     assert np.array_equal(result_obesity, expected_obesity)
 


### PR DESCRIPTION
Change the `switch_to_healthier_population()` function so that it only reduces the obesity status for people in categories Obese I, II and II (previously it was also reducing "overweight" people).