### PR TITLE
Update ramp_ua.cl

### DIFF
--- a/microsim/opencl/ramp/kernels/ramp_ua.cl
+++ b/microsim/opencl/ramp/kernels/ramp_ua.cl
@@ -116,7 +116,7 @@ float get_obesity_multiplier(ushort obesity, global const Params* params){
 }
 
 bool is_overweight(ushort obesity){
-  return obesity > 0;
+  return obesity >= 2;
 }
 
 /*
@@ -334,7 +334,7 @@ kernel void people_update_statuses(uint npeople,
           float mortality_prob = get_mortality_prob_for_age(person_age, params);
 
           ushort person_obesity = people_obesity[person_id]; 
-          if (person_obesity > 0){ // if person is obese then adjust mortality probability
+          if (person_obesity >= 2){ // if person is obese then adjust mortality probability
             mortality_prob *= get_obesity_multiplier(person_obesity, params);
           }
           

--- a/microsim/opencl/ramp/kernels/ramp_ua.cl
+++ b/microsim/opencl/ramp/kernels/ramp_ua.cl
@@ -115,7 +115,7 @@ float get_obesity_multiplier(ushort obesity, global const Params* params){
     return params->obesity_multipliers[multiplier_idx];
 }
 
-bool is_overweight(ushort obesity){
+bool is_obese(ushort obesity){
   return obesity >= 2;
 }
 
@@ -309,7 +309,7 @@ kernel void people_update_statuses(uint npeople,
           float symp_rate = 1 - params->proportion_asymptomatic;
 
           // being overweight increases chances of being symptomatic
-          if (is_overweight(people_obesity[person_id])){
+          if (is_obese(people_obesity[person_id])){
             symp_rate *= params->overweight_sympt_mplier;
           }
 

--- a/tests/opencl/test_update_statuses_kernel.py
+++ b/tests/opencl/test_update_statuses_kernel.py
@@ -135,8 +135,8 @@ def test_more_overweight_become_symptomatic():
 
     people_statuses_test_data = np.full(npeople, DiseaseStatus.Exposed.value, dtype=np.uint32)
     people_transition_times_test_data = np.full(npeople, 1, dtype=np.uint32)
-    # set all people to obesity=1, corresponding to overweight
-    people_obesity_test_data = np.full(npeople, 1, dtype=np.uint8)
+    # set all people to obesity=2, corresponding to overweight
+    people_obesity_test_data = np.full(npeople, 2, dtype=np.uint8)
     people_transition_times_test_data = np.full(npeople, 1, dtype=np.uint32)
 
     snapshot.buffers.people_statuses[:] = people_statuses_test_data


### PR DESCRIPTION
Adjusting so that only people in the Obese I, II, III categories are included as obese and therefore having an increased mortality risk. Previous work had also included overweight people as having increased mortality risk.  Now the obesity scenario will be based on this paper https://onlinelibrary.wiley.com/doi/full/10.1111/obr.13128 which shows obese people having a 48% increased mortality risk when infected with COVID.