### PR TITLE
update version of rpy2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - matplotlib=3.1.3
   - swifter=0.304
   - pyopencl=2020.2.2 
-  - rpy2=3.3.2
+  - rpy2=3.4.2
   - tzlocal
   - r-mixdist
   - r-tidyr=1.1.0


### PR DESCRIPTION
I'm pretty loath to change our underlying environment but i'd like to propose bumping the rpy2 version for two reasons:
1. For whatever reason the Ubuntu Github action test runner cannot run the rInterface tests i've written with our version of rpy2. They work locally and in the macOS test runner but not in the ubuntu runner. The only fix I can find is updating rpy2, this lets us add some more unit tests to the project for the R/python integration step which i'm keen to do.
2. Our difficulties on Windows come down to the rpy2 package, I haven't yet tested it but potentially bumping the version may help resolve this, helping make the python model runnable on windows again.

I'm tagging everyone in this as a reviewer because i'd like everyone to test this change out separately and check they don't have any problems. I've tested it on my machine and all tests pass, the python model runs and the opencl models runs so i'm reasonably confident this shouldn't be a breaking change.

But crucially it means if included everyone will need to update their conda environments:

```bash
cd RAMP-UA

# checkout this pr 
git fetch origin pull/241/head:pr-241

git checkout pr-241

# exit ramp-ua environment
conda deactivate

# remove old environment
conda remove -n ramp-ua --all -y

# create environment from new yml
conda env create -f environment.yml
```