### PR TITLE
Update README.md (initialisation timing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $ python microsim/main.py --opencl-gui
 ```
 
 #### Caching of population initialisation
-The population initialisation step runs before either of the models and can be time consuming (~10 minutes). In order to run
+The population initialisation step runs before either of the models and can be time consuming (~10 minutes or up to 2 hours). In order to run
 the models using a cache of previous results simply pass the `--use-cache` flag.
 
 ### Output Dashboards


### PR DESCRIPTION
Hi all, this is more of a trial of a pull request rather than a serious issue...
Shall we edit the README to reflect the fact that the population initialisation takes (or can take) longer than 10 minutes?
At least on my computer (which I think is rather strong) it takes around 2 hours to run the population initialisation step, I have run it few times already and had always the same performance. Happy to discuss at the stand-up. Thanks!