### PR TITLE
removing python-version in python testing workflow

### DIFF
--- a/.github/workflows/pythontesting.yml
+++ b/.github/workflows/pythontesting.yml
@@ -27,7 +27,6 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         environment-file: environment.yml
-        python-version: 3.7
         auto-activate-base: false
         activate-environment: ramp-ua
 


### PR DESCRIPTION
the latest update to our conda-setup action is failing to create our environment (specifically on the `requirements.txt` pip installs), suggested fix is to remove python-version (https://github.com/conda-incubator/setup-miniconda/issues/162)

If this still fails I will stick the version of this action we use to attempt to fix.