### PR TITLE
removing duplicate reference to usage section

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,7 +16,6 @@ Site contents
    Home <self>
    Usage Guide <usage/index>
    Developers Guide <dev_guide/index>
-   usage/index 
    contributing/index
    Reference/index
 


### PR DESCRIPTION
quick fix for some duplication in `docs/source/index.rst`