### PR TITLE
Fix randomly failing test

### DIFF
--- a/tests/opencl/test_update_statuses_kernel.py
+++ b/tests/opencl/test_update_statuses_kernel.py
@@ -572,7 +572,7 @@ def test_infection_transition_times_distribution(visualize=False):
 
 def test_seed_initial_infections_all_high_risk():
     npeople = 200
-    snapshot = Snapshot.random(nplaces, npeople, nslots)
+    snapshot = Snapshot.zeros(nplaces, npeople, nslots)
 
     # set all people as high risk
     snapshot.area_codes = np.full(npeople, "E02004143")  # high risk area code
@@ -612,14 +612,16 @@ def test_seed_initial_infections_all_high_risk():
     assert num_people_infected == expected_num_infections
 
 
-def test_seed_initial_infections_some_low_risk():
+def test_seed_initial_infections_most_people_low_risk():
     npeople = 200
-    snapshot = Snapshot.random(nplaces, npeople, nslots)
+    snapshot = Snapshot.zeros(nplaces, npeople, nslots)
 
-    # set all people as high risk
+    # set all people as low risk
     snapshot.area_codes = np.full(npeople, "E02004187")  # low risk area code
-    snapshot.area_codes[1:4] = "E02004143"  # high risk area code
     snapshot.not_home_probs = np.full(npeople, 0.0)
+
+    # set 3 people to be high risk
+    snapshot.area_codes[1:4] = "E02004143"  # high risk area code
     snapshot.not_home_probs[1:4] = 0.8
 
     num_seed_days = 5
@@ -637,9 +639,13 @@ def test_seed_initial_infections_some_low_risk():
     people_statuses_after = np.zeros(snapshot.npeople, dtype=np.uint32)
     simulator.download("people_statuses", people_statuses_after)
 
-    expected_num_infections = 3  # taken from devon_initial_cases.csv file
+    # only high risk people will get infected (eg. in a high risk area code and with a high not_home_prob)
+    # so only the 3 high risk people should be infected by the seeding
+    expected_num_infections = 3
 
     num_people_infected = np.count_nonzero(people_statuses_after)
+
+    print(f"\nnum infected: {num_people_infected}\n")
 
     assert num_people_infected == expected_num_infections
 

--- a/tests/opencl/test_update_statuses_kernel.py
+++ b/tests/opencl/test_update_statuses_kernel.py
@@ -645,8 +645,6 @@ def test_seed_initial_infections_most_people_low_risk():
 
     num_people_infected = np.count_nonzero(people_statuses_after)
 
-    print(f"\nnum infected: {num_people_infected}\n")
-
     assert num_people_infected == expected_num_infections
 
 _devon_initial_cases = None


### PR DESCRIPTION
use `Snapshot.zeros()` instead of `Snapshot.random()` for creating initial snapshot data for test. 

The test assumed that there were initially no people infected (i.e. all statuses zero), however because of [this line](https://github.com/Urban-Analytics/RAMP-UA/blob/a2ef5b760c1cd0307586a4f56cb9a8660e8ec627/microsim/opencl/ramp/snapshot.py#L87) in the `Snapshot.random()` function the initial cases are being set with a binomial distribution, which in this test was sometimes giving a single infected person (making the test fail), and sometimes giving no infected people (so the test passed).

I've also added some additional explanatory comments for this test.